### PR TITLE
Add automated testing using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: python
+install: pip install flake8
+script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics


### PR DESCRIPTION
Go to https://travis-ci.com/lihanghang and log in with GitHub credentials to turn on this free service.  Output: https://travis-ci.com/cclauss/Knowledge-Graph/jobs/221103106#L193